### PR TITLE
Removal: VALID_ARCHS

### DIFF
--- a/Resources/xcconfigs/UniversalFramework_Base.xcconfig
+++ b/Resources/xcconfigs/UniversalFramework_Base.xcconfig
@@ -7,11 +7,6 @@
 
 // Make it universal
 SUPPORTED_PLATFORMS                    = macosx iphonesimulator iphoneos appletvos appletvsimulator
-VALID_ARCHS[sdk=macosx*]               = i386 x86_64
-VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
-VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
-VALID_ARCHS[sdk=appletv*]              = arm64
-VALID_ARCHS[sdk=appletvsimulator*]     = x86_64
 
 // Dynamic linking uses different default copy paths
 LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]           = $(inherited) '@executable_path/../Frameworks' '@loader_path/Frameworks'


### PR DESCRIPTION
Apple Silicon machines have `arm64` simulators
Previous configuration wasn't building for these machines
Now we let the compiler decide on `VALID_ARCHS` by default

If specifying `VALID_ARCHS` in `xcconfig` was done out of neccessity somehow, we can add `arm64` to them instead of removing.