### PR TITLE
BUILD_LIBRARY_FOR_DISTRIBUTION set to YES

### DIFF
--- a/Resources/xcconfigs/UniversalFramework_Framework.xcconfig
+++ b/Resources/xcconfigs/UniversalFramework_Framework.xcconfig
@@ -23,6 +23,8 @@ TARGETED_DEVICE_FAMILY[sdk=appletv*]          = 3
 TARGETED_DEVICE_FAMILY[sdk=watchsimulator*]   = 4
 TARGETED_DEVICE_FAMILY[sdk=watch*]            = 4
 
+BUILD_LIBRARY_FOR_DISTRIBUTION                = YES
+
 ENABLE_BITCODE[sdk=macosx*]                   = NO
 ENABLE_BITCODE[sdk=iphonesimulator*]          = YES
 ENABLE_BITCODE[sdk=iphone*]                   = YES


### PR DESCRIPTION
Origin issue: #81 

Preparation step for binary distribution.

If we build `Kronos` with `BUILD_LIBRARY_FOR_DISTRIBUTION = YES` and add the output `xcframework` file as an asset to releases then our users can use this binary in most of the cases (old Xcode versions will still need to fallback to building from source but that's okay i guess). 
Does this make sense? Do you think we need to make other changes as well?

Also, you will need to add this to your release process; is this okay with you?
(I'd be happy to help but this step requires admin rights i guess)