### PR TITLE
BUILD_LIBRARY_FOR_DISTRIBUTION is reverted back to Xcode default

### DIFF
--- a/Resources/xcconfigs/UniversalFramework_Framework.xcconfig
+++ b/Resources/xcconfigs/UniversalFramework_Framework.xcconfig
@@ -23,8 +23,6 @@ TARGETED_DEVICE_FAMILY[sdk=appletv*]          = 3
 TARGETED_DEVICE_FAMILY[sdk=watchsimulator*]   = 4
 TARGETED_DEVICE_FAMILY[sdk=watch*]            = 4
 
-BUILD_LIBRARY_FOR_DISTRIBUTION                = YES
-
 ENABLE_BITCODE[sdk=macosx*]                   = NO
 ENABLE_BITCODE[sdk=iphonesimulator*]          = YES
 ENABLE_BITCODE[sdk=iphone*]                   = YES


### PR DESCRIPTION
Related to https://github.com/MobileNativeFoundation/Kronos/issues/81

This setting is incompatible with ObjC bridging header
Clients lose Swift-ObjC interop

The first PR was raised without having done enough research 🙇 