### PR TITLE
Fix typo in podspec

### DIFF
--- a/Kronos.podspec
+++ b/Kronos.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources/*.swift'
   
-  s.resource_bundles = {'Kronos' => ['Source/PrivacyInfo.xcprivacy']}
+  s.resource_bundles = {'Kronos' => ['Sources/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
Related to https://github.com/MobileNativeFoundation/Kronos/issues/111

There was a typo in the podspec so the `PrivacyInfo.xcprivacy` file was gone missing from the Cocoapods install.